### PR TITLE
refactor: Reorganise default arguments

### DIFF
--- a/lib/frame-maker.js
+++ b/lib/frame-maker.js
@@ -1,14 +1,13 @@
 const path = require('path')
 const validate = require('aproba')
 const { registerFont, createCanvas } = require('canvas-prebuilt/canvas')
-const { defaultFrameRate, defaultFrameFormat, possibleFrameFormats } = require('./constants')
 
 /**
  * Add custom fonts to node-canvas’s environment.
- * @param {Object[]} [fonts=[]] An array of objects specifying font defnitions
+ * @param {Object[]}  fonts An array of objects specifying font defnitions
  * @return {undefined}
  */
-function registerCustomFonts (fonts = []) {
+function registerCustomFonts (fonts) {
   validate('A', [fonts])
   fonts.forEach(font => {
     registerFont(
@@ -28,9 +27,9 @@ module.exports = FrameMaker
  * @param   {Function|Object} sketch    Sketch function
  * @param   {Object[]}  [fonts=[]] Array of objects defining fonts
  * @param   {Number[]}  [dimensions=[640, 480]] Width & height of sketch
- * @param   {Number}    [totalFrames=24]  Total number of frames in animation
- * @param   {Number}    [fps=24]  Frames per second
- * @param   {String}    [frameFormat='png'] Format to export to: 'png', 'jpeg'
+ * @param   {Number}    totalFrames       Total number of frames in animation
+ * @param   {Number}    fps               Frames per second
+ * @param   {String}    frameFormat       Format to export to: 'png', 'jpeg'
  * @return  {Object}    A FrameMaker instance with a getFrame() method
  */
 async function FrameMaker (
@@ -38,10 +37,10 @@ async function FrameMaker (
   {
     fonts = [],
     dimensions = [640, 480],
-    totalFrames = 24,
-    fps = defaultFrameRate,
-    frameFormat = defaultFrameFormat
-  } = {}
+    totalFrames,
+    fps,
+    frameFormat
+  }
 ) {
   validate('FAANNS', [sketch, fonts, dimensions, totalFrames, fps, frameFormat])
 
@@ -70,13 +69,10 @@ async function FrameMaker (
   return {
     /**
      * Get a Buffer representing the image data for a single frame
-     * @param  {Object} [opts={}]   Options object
-     * @param  {Number} [frame=0]   The current frame number
-     * @param  {Number} totalFrames The total number of frames
-     * @param  {Number} [fps=24]    The number of frames per second
+     * @param  {Number} frame       The current frame number
      * @return {Promise<Buffer>}    Resolves to an image buffer
      */
-    getFrame (frame = 0) {
+    getFrame (frame) {
       return new Promise(async (resolve, reject) => {
         const canvas = createCanvas(width, height)
         const context = canvas.getContext('2d')

--- a/lib/frame-maker.js
+++ b/lib/frame-maker.js
@@ -45,10 +45,6 @@ async function FrameMaker (
 ) {
   validate('FAANNS', [sketch, fonts, dimensions, totalFrames, fps, frameFormat])
 
-  if (!possibleFrameFormats.includes(frameFormat)) {
-    throw new RangeError(`frameFormat must be “png” or “jpeg”, got “${frameFormat}”`)
-  }
-
   // In the browser custom fonts are loaded as normal web fonts, but as we’re
   // avoiding the browser, we need to register non-system fonts for use by
   // node-canvas

--- a/lib/frame-writer.js
+++ b/lib/frame-writer.js
@@ -2,30 +2,29 @@ const { writeFile } = require('fs')
 const { join } = require('path')
 const validate = require('aproba')
 const { directory } = require('tempy')
-const { defaultFrameFormat } = require('./constants')
 
 module.exports = FrameWriter
 /**
  * Get a FrameWriter instance
+ * @param  {String} frameFormat Image format to save to
  * @return {Object} A FrameWriter instance with write, getDir & done methods
  */
-function FrameWriter () {
+function FrameWriter (frameFormat) {
+  validate('S', arguments)
   const dir = directory()
   const promises = []
 
   return {
     /**
      * Write a single frame to disk
-     * @param   {Buffer} buffer           An image data buffer
-     * @param   {Number} frame            The number of the frame we’re saving
-     * @param   {Object} [o]              Options object
-     * @param   {String} [o.format='png'] Image format to save to
+     * @param   {Buffer} buffer     An image data buffer
+     * @param   {Number} frame      The number of the frame we’re saving
      * @return  {Object} Returns the FrameWriter instance
      */
-    write (buffer, frame, { format = defaultFrameFormat } = {}) {
-      validate('ON|ONO', arguments)
+    write (buffer, frame) {
+      validate('ON', arguments)
       const promise = new Promise(function (resolve, reject) {
-        const file = `${frame}.${format}`
+        const file = `${frame}.${frameFormat}`
         const path = join(dir, file)
         writeFile(path, buffer, error => {
           if (error) reject(error)

--- a/lib/pellicola.js
+++ b/lib/pellicola.js
@@ -5,7 +5,7 @@ const validate = require('aproba')
 const FrameMaker = require('./frame-maker')
 const FrameWriter = require('./frame-writer')
 const compileVideo = require('./compile-video')
-const { defaultFrameRate, defaultFrameFormat } = require('./constants')
+const { defaultFrameRate, defaultFrameFormat, possibleFrameFormats } = require('./constants')
 
 // pellicola exports a single function that will run the animation generator
 module.exports = pellicola
@@ -47,6 +47,11 @@ async function pellicola (
   } else if (duration && duration * fps !== totalFrames) {
     console.warn(`Warning: You are providing both a duration option (${duration}s) and a totalFrames option (${totalFrames} frames).\n` + `Duration will be used to override the total number of frames.`)
     totalFrames = duration * fps
+  }
+
+  // Make sure the frame format argument is valid
+  if (!possibleFrameFormats.includes(frameFormat)) {
+    throw new RangeError(`frameFormat must be “png” or “jpeg”, got “${frameFormat}”`)
   }
 
   // Initialise our frame maker and writer instances

--- a/lib/pellicola.js
+++ b/lib/pellicola.js
@@ -51,12 +51,12 @@ async function pellicola (
 
   // Initialise our frame maker and writer instances
   const maker = await FrameMaker(sketch, { fonts, dimensions, fps, totalFrames, frameFormat })
-  const writer = FrameWriter()
+  const writer = FrameWriter(frameFormat)
 
   // Run the frame maker for every frame and write the results to disk
   await Promise.all(new Array(totalFrames).fill().map(async (_, frame) => {
     const buffer = await maker.getFrame(frame)
-    writer.write(buffer, frame, { format: frameFormat })
+    writer.write(buffer, frame)
   }))
 
   // Wait for all the write operations to finish


### PR DESCRIPTION
Redistributes and reduces default arguments (e.g. removing those that are always provided a value by the main `pellicola` function)