### PR TITLE
build(npm): Use canvas@2.0.1 instead of canvas-prebuilt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - 10
   - 8
-  - 6
 cache:
   directories:
   - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
-node_js: lts/*
+node_js:
+  - 10
+  - 8
+  - 6
 cache:
   directories:
   - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: stable
+node_js: lts/*
 cache:
   directories:
   - node_modules

--- a/lib/frame-maker.js
+++ b/lib/frame-maker.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const validate = require('aproba')
-const { registerFont, createCanvas } = require('canvas-prebuilt/canvas')
+const { registerFont, createCanvas } = require('canvas')
 
 /**
  * Add custom fonts to node-canvas’s environment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1377,14 +1377,32 @@
         "map-obj": "^1.0.0"
       }
     },
-    "canvas-prebuilt": {
-      "version": "2.0.0-alpha.14",
-      "resolved": "https://registry.npmjs.org/canvas-prebuilt/-/canvas-prebuilt-2.0.0-alpha.14.tgz",
-      "integrity": "sha512-b4QydUnFNxpgctSbHnJWsCDaqtq2AMYa9/B7q4+cGnBrEtMIcLcXpKltT/iSB39AHOTDIprYeHuvyy3h2k1ltg==",
+    "canvas": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.0.1.tgz",
+      "integrity": "sha512-aVESjDBMXGRL+aZqjFtxMVOg8KzHhNcKIscoeC8OROccmApKOriHsnySxq228Kc+3tzB9Qc6tzD4ukp9Zjwz1Q==",
       "requires": {
-        "detect-libc": "^1.0.3",
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.11.1",
+        "node-pre-gyp": "^0.11.0"
+      },
+      "dependencies": {
+        "node-pre-gyp": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+          "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        }
       }
     },
     "capture-stack-trace": {
@@ -5912,9 +5930,9 @@
       }
     },
     "minipass": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.4.tgz",
-      "integrity": "sha512-mlouk1OHlaUE8Odt1drMtG1bAJA4ZA6B/ehysgV0LUIrDHdKgo1KorZq3pK0b/7Z7LJIQ12MNM6aC+Tn6lUZ5w==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -6085,23 +6103,6 @@
       "resolved": "https://registry.npmjs.org/ninos/-/ninos-2.0.2.tgz",
       "integrity": "sha512-cZ93DIgHImup3ML0sK/9SQy3l7e/Gvl4JCm9gDy2FnxaGxqLr36UEVxTbLcWhbHyvLF0rYoJAKwiype8NON4DQ==",
       "dev": true
-    },
-    "node-pre-gyp": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz",
-      "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
-      "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.1",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4"
-      }
     },
     "nopt": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "files": [
     "lib"
   ],
+  "engines": {
+    "node": ">=7.6.0 <11"
+  },
   "scripts": {
     "prerelease": "npm t",
     "release": "standard-version -s",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://npmjs.com/package/pellicola",
   "dependencies": {
     "aproba": "^2.0.0",
-    "canvas-prebuilt": "^2.0.0-alpha.14",
+    "canvas": "^2.0.1",
     "ffmpeg-static": "^2.3.0",
     "mkdirp2": "^1.0.4",
     "tempy": "^0.2.1"


### PR DESCRIPTION
Since v2, `node-canvas` downloads prebuilt binaries wherever possible, so we can depend directly on it rather than on `node-canvas-prebuilt` (which is no longer publishing new versions to npm)