### PR TITLE
feat: Limit concurrency when rendering frames in parallel

### DIFF
--- a/docs/generating-video-files.md
+++ b/docs/generating-video-files.md
@@ -53,6 +53,7 @@ variable           | default      | description
 `fonts`            |              | An array of custom fonts to load (see [‘Using custom fonts’][fonts])
 `fps`              | `24`         | Number of frames per second in the animation
 `frameFormat`      | `'png'`      | Sets canvas export format: either `'png'` or `'jpeg'`
+`maxConcurrency`   | `16`         | If `renderInParallel` is `true`, sets maximum number of frames to render in parallel
 `outDir`           | `'.'`        | Path to the directory to save your video in
 `renderInParallel` | `false`      | If true, renders each frame in parallel in separate canvas contexts
 `totalFrames`      |              | Sets the duration of your video in frames

--- a/lib/pellicola.js
+++ b/lib/pellicola.js
@@ -1,6 +1,7 @@
 // This is the main entry point for this package
 // We will need functionality from some useful external libraries:
 const validate = require('aproba')
+const stau = require('@delucis/stau')
 // We also need functionality that we’ve broken up into other files:
 const logger = require('./logger')
 const FrameMaker = require('./frame-maker')
@@ -22,6 +23,7 @@ module.exports = pellicola
  * @param  {String} outDir                           Directory to write video to
  * @param  {String} filename                         Output video file name
  * @param  {Boolean}  renderInParallel               Render frames in parallel
+ * @param  {Number} maxConcurrency                   Number of parallel frames
  * @param  {Boolean}  [silent=false]                 Suppress progress spinners
  * @return {Promise<String>}  Returns the path to the saved video file
  */
@@ -37,6 +39,7 @@ async function pellicola (
     outDir,
     filename,
     renderInParallel = false,
+    maxConcurrency = 16,
     silent = false
   }
 ) {
@@ -84,7 +87,10 @@ async function pellicola (
   // Run the frame maker for every frame and write the results to disk
   if (renderInParallel) {
     const frames = new Array(totalFrames).fill()
-    await Promise.all(frames.map(async (_, frame) => writeFrame(frame)))
+    await stau(
+      frames.map((_, frame) => () => writeFrame(frame)),
+      maxConcurrency
+    )
   } else {
     for (let frame = 0; frame < totalFrames; frame++) {
       await writeFrame(frame)

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,6 +219,14 @@
         "arrify": "^1.0.1"
       }
     },
+    "@delucis/stau": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@delucis/stau/-/stau-0.1.0.tgz",
+      "integrity": "sha512-10ao1bY0MkvIruTWhA6GR1MHAlGkpTTypA6lUH0HtpwA/Bzth0P4q+x6//s9XFZMH/xL3ZGS0o84OL1FpPR5EA==",
+      "requires": {
+        "aproba": "^2.0.0"
+      }
+    },
     "@ladjs/time-require": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
@@ -7685,7 +7693,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "node-canvas"
   ],
   "dependencies": {
+    "@delucis/stau": "^0.1.0",
     "aproba": "^2.0.0",
     "canvas": "^2.0.1",
     "ffmpeg-static": "^2.3.0",


### PR DESCRIPTION
Currently, when rendering longer animations in parallel, hundreds of `FrameMaker` instances are launched simultaneously causing a spike in CPU usage. This PR uses `@delucis/stau` to limit the maximum number of `FrameMaker`s active at any one time and exposes a `maxConcurrency` option to increase/decrease the default limit of 16.