### PR TITLE
fix: Handle frame render errors better

### DIFF
--- a/lib/frame-maker.js
+++ b/lib/frame-maker.js
@@ -95,7 +95,11 @@ async function FrameMaker (
         const time = frame / fps
         const playhead = frame / (totalFrames - 1)
 
-        await renderFn({ canvas, context, width, height, time, frame, playhead, deltaTime, duration, totalFrames, fps, loadImage, Image, ImageData })
+        try {
+          await renderFn({ canvas, context, width, height, time, frame, playhead, deltaTime, duration, totalFrames, fps, loadImage, Image, ImageData })
+        } catch (error) {
+          reject(error)
+        }
 
         canvas.toBuffer(
           function (error, buffer) {

--- a/lib/pellicola.js
+++ b/lib/pellicola.js
@@ -1,7 +1,7 @@
 // This is the main entry point for this package
 // We will need functionality from some useful external libraries:
 const validate = require('aproba')
-const stau = require('@delucis/stau')
+const PQueue = require('p-queue')
 // We also need functionality that we’ve broken up into other files:
 const logger = require('./logger')
 const FrameMaker = require('./frame-maker')
@@ -77,25 +77,22 @@ async function pellicola (
   }
   progress.start()
 
-  // Wait to get a frame buffer, then send it to be written to disk
-  const writeFrame = async frame => {
-    const buffer = await maker.getFrame(frame)
-    writer.write(buffer, frame)
-    progress.update()
-  }
-
   // Run the frame maker for every frame and write the results to disk
-  if (renderInParallel) {
-    const frames = new Array(totalFrames).fill()
-    await stau(
-      frames.map((_, frame) => () => writeFrame(frame)),
-      maxConcurrency
-    )
-  } else {
-    for (let frame = 0; frame < totalFrames; frame++) {
-      await writeFrame(frame)
-    }
-  }
+  const queue = new PQueue({ concurrency: renderInParallel ? maxConcurrency : 1 })
+  await queue.addAll(new Array(totalFrames)
+    .fill()
+    .map((_, number) => async () => {
+      try {
+        // Wait to get a frame buffer, then send it to be written to disk
+        const buffer = await maker.getFrame(number)
+        writer.write(buffer, number)
+        progress.update()
+      } catch (error) {
+        queue.pause()
+        if (progress.isSpinning) progress.fail()
+        throw error
+      }
+    }))
   progress.succeed()
 
   // Wait for all the write operations to finish

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,14 +219,6 @@
         "arrify": "^1.0.1"
       }
     },
-    "@delucis/stau": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@delucis/stau/-/stau-0.1.0.tgz",
-      "integrity": "sha512-10ao1bY0MkvIruTWhA6GR1MHAlGkpTTypA6lUH0HtpwA/Bzth0P4q+x6//s9XFZMH/xL3ZGS0o84OL1FpPR5EA==",
-      "requires": {
-        "aproba": "^2.0.0"
-      }
-    },
     "@ladjs/time-require": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
@@ -7571,6 +7563,11 @@
       "requires": {
         "p-limit": "^1.1.0"
       }
+    },
+    "p-queue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-3.0.0.tgz",
+      "integrity": "sha512-2tv/MRmPXfmfnjLLJAHl+DdU8p2DhZafAnlpm/C/T5BpF5L9wKz5tMin4A4N2zVpJL2YMhPlRmtO7s5EtNrjfA=="
     },
     "p-try": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "node-canvas"
   ],
   "dependencies": {
-    "@delucis/stau": "^0.1.0",
     "aproba": "^2.0.0",
     "canvas": "^2.0.1",
     "ffmpeg-static": "^2.3.0",
     "mkdirp2": "^1.0.4",
     "ora": "^3.0.0",
+    "p-queue": "^3.0.0",
     "tempy": "^0.2.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -119,6 +119,13 @@ test.cb('a render function can load an image', test => {
   cb(sketch, { totalFrames: 1, outDir: directory() }, test)
 })
 
+test('throws if render function throws an error', async test => {
+  const message = 'Failing render function'
+  const sketch = () => () => { throw new Error(message) }
+  const error = await test.throws(m(sketch, { duration: 1 }))
+  test.is(error.message, message)
+})
+
 test.cb('can show spinners to monitor progress', test => {
   cb(emptySketch, { totalFrames: 1, outDir: directory(), silent: false }, test)
 })


### PR DESCRIPTION
Fixes #16 

If a frame render errors, the render queue is stopped and the error messages are cleaner/properly handled.