### PR TITLE
feat: Clean up temporary frame files by default

### DIFF
--- a/docs/generating-video-files.md
+++ b/docs/generating-video-files.md
@@ -47,6 +47,7 @@ All settings are optional, except that you must include one of either `duration`
 
 variable           | default      | description
 -------------------|--------------|---------------------------------------------------------------------
+`cleanup`          | `true`       | Enable/disable cleanup of temporary files  
 `dimensions`       | `[640, 480]` | Sets `[width, height]` of your video
 `duration`         |              | Sets the duration of your video in seconds
 `filename`         | `'out.mp4'`  | Sets the filename of your video

--- a/lib/pellicola.js
+++ b/lib/pellicola.js
@@ -2,6 +2,7 @@
 // We will need functionality from some useful external libraries:
 const validate = require('aproba')
 const PQueue = require('p-queue')
+const del = require('del')
 // We also need functionality that we’ve broken up into other files:
 const logger = require('./logger')
 const FrameMaker = require('./frame-maker')
@@ -28,6 +29,7 @@ module.exports = pellicola
  * @param  {Number} maxConcurrency                   Number of parallel frames
  * @param  {Boolean}  [silent=false]                 Suppress progress spinners
  * @param  {Object} motionBlur                       Configure motion blur
+ * @param  {Boolean} [cleanup=true]                  Enable/disable cleanup
  * @return {Promise<String>}  Returns the path to the saved video file
  */
 async function pellicola (
@@ -46,7 +48,8 @@ async function pellicola (
     renderInParallel = false,
     maxConcurrency = 16,
     silent = false,
-    motionBlur
+    motionBlur,
+    cleanup = true
   }
 ) {
   validate('FO', arguments)
@@ -126,5 +129,13 @@ async function pellicola (
 
   const writeVideo = compileVideo(writer.getDir(), { outDir, filename, fps, frameFormat, initialFrame })
   ora.promise(writeVideo, 'Compiling video')
-  return writeVideo
+  const writePath = await writeVideo
+
+  if (cleanup) {
+    const cleaner = del(writer.getDir(), { force: true })
+    ora.promise(cleaner, 'Cleaning up temporary files')
+    await cleaner
+  }
+
+  return writePath
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -433,7 +433,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
       "requires": {
         "array-uniq": "^1.0.1"
       }
@@ -441,8 +440,7 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
     },
     "array-unique": {
       "version": "0.2.1",
@@ -2636,48 +2634,22 @@
       }
     },
     "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "requires": {
-        "globby": "^5.0.0",
+        "globby": "^6.1.0",
         "is-path-cwd": "^1.0.0",
         "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
         "rimraf": "^2.2.8"
       },
       "dependencies": {
-        "globby": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-          "dev": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "^2.0.0"
-          }
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
@@ -3475,6 +3447,52 @@
         "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
         "write": "^0.2.1"
+      },
+      "dependencies": {
+        "del": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+          "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+          "dev": true,
+          "requires": {
+            "globby": "^5.0.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "http://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        }
       }
     },
     "fn-name": {
@@ -4597,7 +4615,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-      "dev": true,
       "requires": {
         "array-union": "^1.0.1",
         "glob": "^7.0.3",
@@ -4609,14 +4626,12 @@
         "pinkie": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
         },
         "pinkie-promise": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
           "requires": {
             "pinkie": "^2.0.0"
           }
@@ -5171,14 +5186,12 @@
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
     },
     "is-path-in-cwd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
       "requires": {
         "is-path-inside": "^1.0.0"
       }
@@ -5187,7 +5200,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
       "requires": {
         "path-is-inside": "^1.0.1"
       }
@@ -7564,6 +7576,11 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+    },
     "p-queue": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-3.0.0.tgz",
@@ -7658,8 +7675,7 @@
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
     },
     "path-key": {
       "version": "2.0.1",
@@ -7691,8 +7707,7 @@
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "aproba": "^2.0.0",
     "canvas": "^2.0.1",
+    "del": "^3.0.0",
     "ffmpeg-static": "^2.3.0",
     "mkdirp2": "^1.0.4",
     "ora": "^3.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -2,10 +2,11 @@ import ava from 'ava'
 import ninos from 'ninos'
 import fs from 'fs'
 import path from 'path'
-import { directory } from 'tempy'
+import tempy from 'tempy'
 import m from '../lib/pellicola'
 
 const test = ninos(ava)
+const { directory } = tempy
 
 const emptySketch = () => () => {}
 
@@ -176,4 +177,8 @@ test('throws if render function throws an error', async test => {
 
 test.cb('can show spinners to monitor progress', test => {
   cb(emptySketch, { totalFrames: 1, outDir: directory(), silent: false }, test)
+})
+
+test.cb('can disable temporary file cleanup', test => {
+  cb(emptySketch, { totalFrames: 1, outDir: directory(), cleanup: false }, test)
 })


### PR DESCRIPTION
This changes behaviour (probably harmlessly in most cases) and can be disabled by passing `{ cleanup: false }` to `pellicola`.

Closes #22