### PR TITLE
feat: Fix start frame option and add end frame option

### DIFF
--- a/docs/generating-video-files.md
+++ b/docs/generating-video-files.md
@@ -50,6 +50,8 @@ variable           | default      | description
 `cleanup`          | `true`       | Enable/disable cleanup of temporary files  
 `dimensions`       | `[640, 480]` | Sets `[width, height]` of your video
 `duration`         |              | Sets the duration of your video in seconds
+`endFrame`         | `totalFrames` | Sets the frame on which your video ends
+`endTime`          | `duration`   | Sets the time at which your video ends
 `filename`         | `'out.mp4'`  | Sets the filename of your video
 `fonts`            |              | An array of custom fonts to load (see [‘Using custom fonts’][fonts])
 `fps`              | `24`         | Number of frames per second in the animation

--- a/lib/compile-video.js
+++ b/lib/compile-video.js
@@ -23,7 +23,7 @@ function compileVideo (
     filename = 'out.mp4',
     fps = defaultFrameRate,
     frameFormat = defaultFrameFormat,
-    initialFrame
+    startFrame
   }
 ) {
   validate('S|SO', arguments)
@@ -39,7 +39,7 @@ function compileVideo (
       '-v', 'warning',
       '-y', // overwrite files without asking
       '-framerate', fps,
-      '-start_number', initialFrame, // start compiling from …00.png
+      '-start_number', startFrame, // start compiling from …00.png
       '-i', framesPath, // pattern matching generated frames’ paths
       '-c:v', 'libx264',
       '-vf', `fps=${fps},format=yuv420p`,

--- a/lib/frame-maker.js
+++ b/lib/frame-maker.js
@@ -28,6 +28,8 @@ module.exports = FrameMaker
  * @param   {Object[]}  [fonts=[]] Array of objects defining fonts
  * @param   {Number[]}  [dimensions=[640, 480]] Width & height of sketch
  * @param   {Number}    totalFrames       Total number of frames in animation
+ * @param   {Number}    startFrame        First frame to render
+ * @param   {Number}    endFrame          Last frame to render
  * @param   {Number}    fps               Frames per second
  * @param   {String}    frameFormat       Format to export to: 'png', 'jpeg'
  * @param   {Boolean}   renderInParallel  Set the renderer to run in parallel
@@ -40,6 +42,8 @@ async function FrameMaker (
     fonts = [],
     dimensions = [640, 480],
     totalFrames,
+    startFrame,
+    endFrame,
     fps,
     frameFormat,
     renderInParallel,
@@ -49,7 +53,7 @@ async function FrameMaker (
     } = {}
   }
 ) {
-  validate('FAANNSBNN', [sketch, fonts, dimensions, totalFrames, fps, frameFormat, renderInParallel, samplesPerFrame, shutterAngle])
+  validate('FAANNNNSBNN', [sketch, fonts, dimensions, totalFrames, startFrame, endFrame, fps, frameFormat, renderInParallel, samplesPerFrame, shutterAngle])
 
   // In the browser custom fonts are loaded as normal web fonts, but as we’re
   // avoiding the browser, we need to register non-system fonts for use by
@@ -64,7 +68,7 @@ async function FrameMaker (
   // Following canvas-sketch, a sketch function should either return a function
   // that renders a canvas, or an object with a function as its render property
   const renderer = await sketch(
-    { width, height, duration, totalFrames, fps, loadImage, ImageData }
+    { width, height, duration, totalFrames, frame: startFrame, endFrame, fps, loadImage, ImageData }
   )
   let renderFn
   if (typeof renderer === 'function') {

--- a/lib/pellicola.js
+++ b/lib/pellicola.js
@@ -23,6 +23,8 @@ module.exports = pellicola
  * @param  {Number} totalFrames                      Animation length in frames
  * @param  {Number} [time=0]                         Start time in seconds
  * @param  {Number} [frame=0]                        Initial frame number
+ * @param  {Number} endTime                          Time to stop rendering at
+ * @param  {Number} endFrame                         Last frame number to render
  * @param  {String} outDir                           Directory to write video to
  * @param  {String} filename                         Output video file name
  * @param  {Boolean}  renderInParallel               Render frames in parallel

--- a/lib/pellicola.js
+++ b/lib/pellicola.js
@@ -43,6 +43,8 @@ async function pellicola (
     totalFrames,
     time = 0,
     frame = 0,
+    endTime,
+    endFrame,
     outDir,
     filename,
     renderInParallel = false,
@@ -70,20 +72,31 @@ async function pellicola (
   }
 
   // Make sure we have a valid initial frame number
-  let initialFrame = frame
+  let startFrame = frame
   if (time && !frame) {
-    initialFrame = Math.round(time * fps)
+    startFrame = Math.round(time * fps)
   } else if (time && Math.round(time * fps) !== frame) {
     console.warn(`Warning: You are providing both a time option (${time}s) and a frame option (${frame} frames).\n` + `Time will be used to override the initial frame.`)
-    initialFrame = Math.round(time * fps)
+    startFrame = Math.round(time * fps)
   }
 
-  // Adjust totalFrames by initial frame offset
-  totalFrames -= initialFrame
-
   // Make sure there are some frames to render
-  if (totalFrames < 1) {
+  if (totalFrames - startFrame < 1) {
     throw new Error(`No frames to render! Try increasing the “duration” or “totalFrames” options`)
+  }
+
+  if (!endTime && !endFrame) {
+    endFrame = totalFrames
+  } else if (endTime && !endFrame) {
+    endFrame = Math.round(endTime * fps)
+  } else if (endTime && Math.round(endTime * fps) !== endFrame) {
+    console.warn(`Warning: You are providing both an endTime option (${endTime}s) and an endFrame option (${endFrame} frames).\n` + `endTime will be used to override the final frame.`)
+    endFrame = Math.round(endTime * fps)
+  }
+
+  if (endFrame > totalFrames) {
+    console.warn(`Warning: You are specifying an endFrame (${endFrame}) that is beyond the end of the specified sketch duration (${totalFrames} frames). Output will be truncated.`)
+    endFrame = totalFrames
   }
 
   // Make sure the frame format argument is valid
@@ -92,25 +105,28 @@ async function pellicola (
   }
 
   // Initialise our frame maker and writer instances
-  const maker = await FrameMaker(sketch, { fonts, dimensions, fps, totalFrames, frameFormat, renderInParallel, motionBlur })
+  const maker = await FrameMaker(sketch, { fonts, dimensions, fps, totalFrames, startFrame, endFrame, frameFormat, renderInParallel, motionBlur })
   const writer = FrameWriter(frameFormat)
+
+  // Adjust totalFrames by initial frame offset
+  const framesToRender = endFrame - startFrame
 
   // Get a terminal spinner to display frame rendering progress
   const progress = ora('Rendering frames')
   progress.update = function updateProgress () {
     progress.done ? progress.done++ : progress.done = 1
-    progress.text = `Rendering frames (${progress.done}/${totalFrames})`
+    progress.text = `Rendering frames (${progress.done}/${framesToRender})`
   }
   progress.start()
 
   // Run the frame maker for every frame and write the results to disk
   const queue = new PQueue({ concurrency: renderInParallel ? maxConcurrency : 1 })
-  await queue.addAll(new Array(totalFrames)
+  await queue.addAll(new Array(framesToRender)
     .fill()
     .map((_, number) => async () => {
       try {
         // Wait to get a frame buffer, then send it to be written to disk
-        const frameNumber = initialFrame + number
+        const frameNumber = startFrame + number
         const buffer = await maker.getFrame(frameNumber)
         writer.write(buffer, frameNumber)
         progress.update()
@@ -127,7 +143,7 @@ async function pellicola (
   ora.promise(writeFrames, 'Writing frames to disk')
   await writeFrames
 
-  const writeVideo = compileVideo(writer.getDir(), { outDir, filename, fps, frameFormat, initialFrame })
+  const writeVideo = compileVideo(writer.getDir(), { outDir, filename, fps, frameFormat, startFrame })
   ora.promise(writeVideo, 'Compiling video')
   const writePath = await writeVideo
 

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,32 @@ test.cb('can render with a frame offset', test => {
   cb(emptySketch, { duration: 1, frame: 5, outDir: directory() }, test)
 })
 
+test('rendering with an offset provides correct context variables', async test => {
+  const sketch = () => ({ duration, totalFrames, playhead, frame }) => {
+    test.log({ duration, totalFrames, playhead, frame })
+    test.is(playhead, 1)
+    test.is(frame, 47)
+    test.is(duration, 2)
+    test.is(totalFrames, 48)
+  }
+  await m(sketch, { duration: 2, frame: 47, outDir: directory(), silent: true })
+})
+
+test.cb('can render with a frame truncation', test => {
+  cb(emptySketch, { duration: 1, endFrame: 12, outDir: directory() }, test)
+})
+
+test.cb('can render with a time truncation', test => {
+  cb(emptySketch, { duration: 1, endTime: 0.5, outDir: directory() }, test)
+})
+
+test('can render a portion of a sketch', async test => {
+  let count = 0
+  const sketch = () => () => { count++ }
+  await m(sketch, { duration: 2, time: 0.5, endTime: 1.5, outDir: directory() })
+  test.is(count, 24)
+})
+
 test.cb('can render frames in parallel', test => {
   cb(emptySketch, { renderInParallel: true, duration: 0.5, outDir: directory() }, test)
 })

--- a/test/test.js
+++ b/test/test.js
@@ -120,6 +120,14 @@ const warningTests = [
   {
     name: 'non-matching time & frame should raise a warning',
     opts: { time: 0.7, frame: 7 }
+  },
+  {
+    name: 'non-matching endTime & endFrame should raise a warning',
+    opts: { endTime: 0.7, endFrame: 7 }
+  },
+  {
+    name: 'an endFrame beyond the end of the duration should raise a warning',
+    opts: { duration: 1, endFrame: 25 }
   }
 ]
 

--- a/test/test.js
+++ b/test/test.js
@@ -112,16 +112,23 @@ test.cb('FrameMaker can use a sketch that returns an object', test => {
   cb(sketch, { duration: 0.25, outDir: directory() }, test)
 })
 
-test('non-matching duration & totalFrames should raise a warning', async test => {
-  const spy = test.context.spy(console, 'warn', () => {})
-  await m(emptySketch, { duration: 1, totalFrames: 12, outDir: directory(), silent: true })
-  test.is(spy.calls.length, 1)
-})
+const warningTests = [
+  {
+    name: 'non-matching duration & totalFrames should raise a warning',
+    opts: { duration: 1, totalFrames: 12 }
+  },
+  {
+    name: 'non-matching time & frame should raise a warning',
+    opts: { time: 0.7, frame: 7 }
+  }
+]
 
-test('non-matching time & frame should raise a warning', async test => {
-  const spy = test.context.spy(console, 'warn', () => {})
-  await m(emptySketch, { duration: 1, time: 0.7, frame: 7, outDir: directory(), silent: true })
-  test.is(spy.calls.length, 1)
+warningTests.forEach(({ name, opts }) => {
+  test(name, async test => {
+    const spy = test.context.spy(console, 'warn', () => {})
+    await m(emptySketch, { duration: 1, outDir: directory(), silent: true, ...opts })
+    test.is(spy.calls.length, 1)
+  })
 })
 
 test.cb('duration can be set using totalFrames option', test => {


### PR DESCRIPTION
Fixes starting a render at a given frame and enables partial renders of a sketch using `frame`/`endFrame` and `time`/`endTime` options passed to `pellicola`