### PR TITLE
ci(Travis): Drop Node 11 from test matrix and add Node 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
+  - 13
   - 12
-  - 11
   - 10
 cache:
   directories:


### PR DESCRIPTION
Node 11 is no longer intended to be supported. Testing against Node 13 will prepare for Node 14 support later in 2020.